### PR TITLE
A2CP-422 added wpcli method to expose is_active

### DIFF
--- a/core/A2_Optimized_CLI.php
+++ b/core/A2_Optimized_CLI.php
@@ -330,6 +330,34 @@ class A2_Optimized_CLI {
 	}
 
 	/**
+	 * Returns status of specified security options
+	 */
+	public function is_active($args, $assoc_args) {
+		$optimizations = new A2_Optimized_Optimizations;
+		$return = array();
+
+		$specialMapping = array(
+			'lock_plugins' => 'lock_editing',
+			'bcrypt' => 'a2_bcrypt_passwords',
+		);
+	
+		if (count($args) > 0) {
+			$slugs = explode(',', $args[0]);
+				
+			foreach ($slugs as $slug) {
+				$name = $slug;
+				if (array_key_exists($slug, $specialMapping)) {
+					$name = $specialMapping[$slug];
+				}
+				$stat = $optimizations->is_active($name, TRUE);
+				$return[$slug] = $stat;
+			}
+		}
+
+		return WP_CLI::line(json_encode($return));
+	}
+
+	/**
 	 * Returns a site health report for the current site
 	 */
 	public function send_report_data($args, $assoc_args) {

--- a/core/A2_Optimized_CLI.php
+++ b/core/A2_Optimized_CLI.php
@@ -357,7 +357,10 @@ class A2_Optimized_CLI {
 			'lock_plugins' => 'lock_editing',
 			'bcrypt' => 'a2_bcrypt_passwords',
 			'remove_conf_backups' => 'a2_wpconfig_cleanup',
+			'xmlrpc' => 'xmlrpc_requests',
 		);
+
+		$output_json = (array_key_exists('format', $assoc_args) && $assoc_args['format'] == 'json');
 	
 		if (count($args) > 0) {
 			$slugs = explode(',', $args[0]);
@@ -367,12 +370,21 @@ class A2_Optimized_CLI {
 				if (array_key_exists($slug, $specialMapping)) {
 					$name = $specialMapping[$slug];
 				}
-				$stat = $optimizations->is_active($name, FALSE);
+				$stat = $optimizations->is_active($name, !$output_json);
 				$return[$slug] = $stat;
 			}
 		}
 
-		return WP_CLI::line(json_encode($return));
+		if ($output_json) {
+			return WP_CLI::line(json_encode($return));
+		} else {
+			foreach ($return as $slug => $v) {
+				echo "$slug is " . ($v === true ? 'Active' : 'Inactive') . "\n\r";
+			}
+
+			return;
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
**Ticket**

https://a2hosting.atlassian.net/browse/A2CP-422


**Context**

In order to get the various security statuses we need to be able to use WPCLI to git the A2Optimized plugin and get them.

**Changes**

Added CLI command `is_active` so that we can pass in a comma seperated string of statuses we want and get an array of their returned values.

**Considerations**

Will require a release of the plugin, may need to be bundled with any queued releases.

**How was this tested?**

On local development environment against TH local environment
