### PR TITLE
A2OPT-724 and A2OPT-724 add cli regenerate_salts remove_conf_backups

### DIFF
--- a/core/A2_Optimized_CLI.php
+++ b/core/A2_Optimized_CLI.php
@@ -192,6 +192,17 @@ class A2_Optimized_CLI {
 				}
 
 				break;
+			case 'regenerate_salts':
+				$optimizations->regenerate_wpconfig_salts();
+
+				return WP_CLI::success(esc_html__( $site_type . ' salts have been regenerated.', 'a2-optimized-wp' ));
+
+				break;
+			case 'remove_conf_backups':
+					$optimizations->enable_wpconfig_cleanup();
+					
+					return WP_CLI::success(esc_html__( $site_type . ' config backups are scheduled to be removed.', 'a2-optimized-wp' )); 
+				break;
 		}
 	}
 
@@ -285,6 +296,12 @@ class A2_Optimized_CLI {
 				return WP_CLI::success(esc_html__( $site_type . ' Bcrypt passwords disabled.', 'a2-optimized-wp' ));
 
 				break;
+			case 'remove_conf_backups':
+				$optimizations->disable_wpcon;
+
+				return WP_CLI::success(esc_html__( $site_type . ' No longer removing config backups.', 'a2-optimized-wp' ));
+
+				break;
 		}
 	}
 
@@ -339,6 +356,7 @@ class A2_Optimized_CLI {
 		$specialMapping = array(
 			'lock_plugins' => 'lock_editing',
 			'bcrypt' => 'a2_bcrypt_passwords',
+			'remove_conf_backups' => 'a2_wpconfig_cleanup',
 		);
 	
 		if (count($args) > 0) {
@@ -349,7 +367,7 @@ class A2_Optimized_CLI {
 				if (array_key_exists($slug, $specialMapping)) {
 					$name = $specialMapping[$slug];
 				}
-				$stat = $optimizations->is_active($name, TRUE);
+				$stat = $optimizations->is_active($name, FALSE);
 				$return[$slug] = $stat;
 			}
 		}

--- a/core/A2_Optimized_CLI.php
+++ b/core/A2_Optimized_CLI.php
@@ -297,7 +297,7 @@ class A2_Optimized_CLI {
 
 				break;
 			case 'remove_conf_backups':
-				$optimizations->disable_wpcon;
+				$optimizations->disable_wpconfig_cleanup();
 
 				return WP_CLI::success(esc_html__( $site_type . ' No longer removing config backups.', 'a2-optimized-wp' ));
 


### PR DESCRIPTION
**Ticket**

https://a2hosting.atlassian.net/browse/A2OPT-723
https://a2hosting.atlassian.net/browse/A2OPT-724


**Context**

We needed to expose the methods for regenerating salts and enabling the config backup removal cron so that THAgent could pass the command from THWeb.

**Changes**

Updated the CLI case statement to add the ability to call `regenerate_salts` and `remove_conf_backups`, updated the return for `is_active` to send back the array result

**Considerations**

Merging into A2CP-422 so we can push all things at the same time/release

**How was this tested?**

Tested on local WP instance with dev RabbitMQ
