### PR TITLE
Changed "Wordpress" to "WordPress"

### DIFF
--- a/app/models/admin/class-admin-settings.php
+++ b/app/models/admin/class-admin-settings.php
@@ -499,7 +499,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\' . 'Admin_Settings' ) ) {
 				'color_class' => 'warn'
 			],
 			'a2hosting-other' => [
-				'display_text' => 'Managed Wordpress',
+				'display_text' => 'Managed WordPress',
 				'metric_text' => '',
 				'explanation' => '',
 				'color_class' => 'success'
@@ -507,7 +507,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\' . 'Admin_Settings' ) ) {
 			'webperformance' => [
 				'display_text' => 'Web Performance',
 				'metric_text' => "How does your hosting <strong>compare</strong> to A2 Hosting's best plans? With the graphs below <strong>LOWER IS BETTER</strong>.",
-				'legend_text' => "Overall Wordpress Execution Time",
+				'legend_text' => "Overall WordPress Execution Time",
 				'explanation' => 'The web performance score measures how your current host performs compared to A2 Hosting. This web performance score looks at server speed and other metrics to determine how fast your website will load, based on which hosting company & plan you host your website with. <br /><br />
 				The lower the score on the graph the faster your website will load. Not all hosting companies and plans use the same hardware. A2 Hosting uses the best server hardware on the market, focusing on speed & security. A2 Hosting also offers free site migration to help you move your existing websites to them.<br /><br />
 				Graphs are representitive of the following, and individual results may vary based on current server load, PHP version, WordPress version, etc.<br />
@@ -549,7 +549,7 @@ if ( ! class_exists( __NAMESPACE__ . '\\' . 'Admin_Settings' ) ) {
 				],
 			],
 			'hostingmatchup_tooltips' => [
-				'wordpress_db' => 'Wordpress Database Response Time',
+				'wordpress_db' => 'WordPress Database Response Time',
 				'filesystem' => 'Server Disk Response Time',
 				'mysql' => 'MYSQL Query Response Time',
 				'php' => 'PHP Response Time'

--- a/app/templates/admin/page-settings/page-settings.php
+++ b/app/templates/admin/page-settings/page-settings.php
@@ -864,8 +864,8 @@
 					<ul id="menu-links" class="dropdown-menu" aria-labelledby="drop-links-wrapper">
 						<li><a target="_blank" href="https://my.a2hosting.com/">A2 Client Area</a></li>
 						<li><a target="_blank" href="https://my.a2hosting.com/submitticket.php?action=support">A2 Client Support</a></li>
-						<li><a target="_blank" href="https://wordpress.org/support/plugin/a2-optimized-wp/">Wordpress Support</a></li>
-						<li><a target="_blank" href="https://www.a2hosting.com/kb/collections/wordpress-articles">Wordpress Knowledge Base</a></li>
+						<li><a target="_blank" href="https://wordpress.org/support/plugin/a2-optimized-wp/">WordPress Support</a></li>
+						<li><a target="_blank" href="https://www.a2hosting.com/kb/collections/wordpress-articles">WordPress Knowledge Base</a></li>
 					</ul>
 				</div>
 			</div>

--- a/core/A2_Optimized_CLI.php
+++ b/core/A2_Optimized_CLI.php
@@ -595,7 +595,7 @@ class A2_Optimized_CLI {
 							break;
 						case 'wordpress':
 							if (!$output_json) {
-								echo "Running Wordpress benchmarks. Please wait a moment.\r\n";
+								echo "Running WordPress benchmarks. Please wait a moment.\r\n";
 							}
 							$result = $a2opt_benchmark->run_wordpress_benchmarks();
 							$result = $result['queries_per_second'];

--- a/core/A2_Optimized_DB_Optimizations.php
+++ b/core/A2_Optimized_DB_Optimizations.php
@@ -77,7 +77,7 @@ class A2_Optimized_DBOptimizations {
 	}
 
 	/**
-	 * Update a Wordpress setting in the toggles array.
+	 * Update a WordPress setting in the toggles array.
 	 *
 	 * @param string $setting  The setting to update in the toggles array
 	 * @param bool $value      Update the setting to true or false
@@ -198,7 +198,7 @@ class A2_Optimized_DBOptimizations {
 	}
 
 	/**
-	 * Optimize Wordpress tables
+	 * Optimize WordPress tables
 	 */
 	public function optimize_tables() {
 		$query = 'SHOW TABLES';

--- a/core/A2_Optimized_Optimizations.php
+++ b/core/A2_Optimized_Optimizations.php
@@ -869,13 +869,13 @@ class A2_Optimized_Optimizations {
 			],
 			'themes' => [
 				'title' => 'Unused Themes',
-				'description' => 'Unused, non-default themes should be deleted.  For more information read the Wordpress.org Codex on <a target="_blank" href="http://codex.wordpress.org/WordPress_Housekeeping#Theme_Housekeeping">WordPress Housekeeping</a>',
+				'description' => 'Unused, non-default themes should be deleted.  For more information read the WordPress.org Codex on <a target="_blank" href="http://codex.wordpress.org/WordPress_Housekeeping#Theme_Housekeeping">WordPress Housekeeping</a>',
 				'config_url' => admin_url() . 'themes.php',
 				'status' => $this->is_active('themes', false),
 			],
 			'plugins' => [
 				'title' => 'Inactive Plugins',
-				'description' => 'Unused, inactive plugins should be deleted. WordPress will still check for updates on each plugin even if it is not active, which could slow down your site. For more information read the Wordpress.org Codex on <a target="_blank" href="http://codex.wordpress.org/WordPress_Housekeeping">WordPress Housekeeping</a>',
+				'description' => 'Unused, inactive plugins should be deleted. WordPress will still check for updates on each plugin even if it is not active, which could slow down your site. For more information read the WordPress.org Codex on <a target="_blank" href="http://codex.wordpress.org/WordPress_Housekeeping">WordPress Housekeeping</a>',
 				'config_url' => admin_url() . 'plugins.php',
 				'status' => $this->is_active('plugins', false),
 			],


### PR DESCRIPTION
Just changed the string "Wordpress" to "WordPress" to match the correct way to write it.

More info here: https://make.wordpress.org/docs/style-guide/word-list/w/#wordpress